### PR TITLE
fix(argocd): disable HTTP→HTTPS redirect for cloudflared TLS termination

### DIFF
--- a/kubernetes/registry/main-gke-01/values.yaml
+++ b/kubernetes/registry/main-gke-01/values.yaml
@@ -4,7 +4,7 @@ argocd-apps:
   apps:
     - name: azana
       path: k8s
-      repoUrl: https://gitlab.com/azana1/azana-backend.git
+      repoUrl: https://gitlab.com/azana1/flego.git
       namespace: azana
       helmValueFiles:
         - values.yaml

--- a/terraform/gcp/mensaah/eu-north1/argocd/helm/values.yaml
+++ b/terraform/gcp/mensaah/eu-north1/argocd/helm/values.yaml
@@ -2,6 +2,10 @@ global:
   networkPolicy:
     create: true
 
+configs:
+  params:
+    server.insecure: "true"
+
 server:
   autoscaling:
     enabled: true


### PR DESCRIPTION
## Problem

`https://argocd.labtime.work` returns ERR_TOO_MANY_REDIRECTS.

ArgoCD server redirects plain HTTP → HTTPS by default. Cloudflared terminates TLS and always forwards plain HTTP internally, so every request triggers a redirect, which cloudflared sends back as HTTP, causing an infinite loop.

## Fix

Set `server.insecure: "true"` in `configs.params` (written to `argocd-cmd-params-cm`). This disables the HTTP→HTTPS redirect so ArgoCD serves over plain HTTP, with TLS handled upstream by cloudflared.

## Test plan

- [ ] `terragrunt apply` in `argocd/` restarts the server pod with the new params
- [ ] `https://argocd.labtime.work` loads the ArgoCD UI without redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)