### PR TITLE
fix(registry): update azana app path to backend/k8s

### DIFF
--- a/kubernetes/registry/main-gke-01/values.yaml
+++ b/kubernetes/registry/main-gke-01/values.yaml
@@ -3,7 +3,7 @@ argocd-apps:
   server: https://kubernetes.default.svc
   apps:
     - name: azana
-      path: k8s
+      path: backend/k8s
       repoUrl: https://gitlab.com/azana1/flego.git
       namespace: azana
       helmValueFiles:

--- a/terraform/gcp/.tool-versions
+++ b/terraform/gcp/.tool-versions
@@ -1,0 +1,1 @@
+terragrunt 0.99.0


### PR DESCRIPTION
## Summary

- The flego repo restructured the Helm chart under `backend/k8s/`. The ArgoCD `Application` was still pointing at `k8s/main-gke-01` which no longer exists in the repo, causing sync failures.
- Pins `terragrunt` to `0.99.0` for the `terraform/gcp/` directory via `.tool-versions`.

## Test plan

- [ ] ArgoCD syncs `main-gke-01-azana` successfully after merge
- [ ] No `path not found` errors in ArgoCD app events

🤖 Generated with [Claude Code](https://claude.com/claude-code)