### PR TITLE
fix(grafana): correct git sync API group, namespace and repo type

### DIFF
--- a/kubernetes/apps/monitoring/main-gke-01/provisioning/grafana-gitlab-azana-repository.yaml
+++ b/kubernetes/apps/monitoring/main-gke-01/provisioning/grafana-gitlab-azana-repository.yaml
@@ -1,22 +1,15 @@
-# This is NOT a Kubernetes manifest — do not kubectl apply or add to templates/.
-# Push to Grafana via: gcx resources push --path provisioning/
-# gcx must be pointed at https://grafana.labtime.work
-#
-# Docs: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/
-apiVersion: provisioning.grafana.com/v0alpha1
+apiVersion: provisioning.grafana.app/v0alpha1
 kind: Repository
 metadata:
   name: grafana-dashboards
-  namespace: monitoring
+  namespace: default
 spec:
   title: Azana
-  type: gitlab
-  gitlab:
-    url: https://gitlab.com/azana1/flego
+  type: git
+  git:
+    url: https://gitlab.com/azana1/flego.git
     branch: main
     path: backend/k8s/dashboards
-    secure:
-      token: { create: "${GITLAB_TOKEN}" }
   sync:
     enabled: true
     intervalSeconds: 60
@@ -24,3 +17,6 @@ spec:
   workflows:
     - write
     - branch
+secure:
+  token:
+    create: "${GITLAB_TOKEN}"

--- a/kubernetes/apps/monitoring/main-gke-01/templates/grafana-git-sync-job.yaml
+++ b/kubernetes/apps/monitoring/main-gke-01/templates/grafana-git-sync-job.yaml
@@ -57,7 +57,7 @@ spec:
 
                 case "$kind" in
                   Repository)
-                    api_path="/apis/provisioning.grafana.com/v0alpha1/namespaces/${namespace}/repositories"
+                    api_path="/apis/provisioning.grafana.app/v0alpha1/namespaces/${namespace}/repositories"
                     ;;
                   *)
                     echo "Unknown kind '$kind' in $f, skipping"


### PR DESCRIPTION
## Summary

Fixes discovered via live debugging against Grafana 13.0.1 after PR #13 was merged:

- **Wrong API group**: `provisioning.grafana.com` → `provisioning.grafana.app`
- **Wrong namespace**: Grafana's internal org namespace is `default`, not the Kubernetes namespace `monitoring`
- **Unsupported type**: OSS Grafana does not support `type: gitlab`; use `type: git` with `secure.token` at the spec root level
- **URL format**: Added `.git` suffix required by the generic git provider

Confirmed working end-to-end — sync pulled 1 dashboard and 1 folder from `gitlab.com/azana1/flego`.

## Test plan

- [ ] ArgoCD sync completes in `monitoring` namespace
- [ ] PostSync Job `grafana-gitlab-sync-setup` completes successfully
- [ ] Repository appears in Grafana → Administration → Git Sync with `healthy: true`
- [ ] Dashboards from `backend/k8s/dashboards` are visible in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)